### PR TITLE
Adding await/async for buildWebOptions. Changing token request to a string body.

### DIFF
--- a/src/web-utils.test.ts
+++ b/src/web-utils.test.ts
@@ -1,5 +1,5 @@
-import {OAuth2AuthenticateOptions} from "./definitions";
-import {CryptoUtils, WebUtils} from "./web-utils";
+import { OAuth2AuthenticateOptions } from "./definitions";
+import { CryptoUtils, WebUtils } from "./web-utils";
 
 const googleOptions: OAuth2AuthenticateOptions = {
     appId: "appId",
@@ -77,8 +77,8 @@ describe('base options processing', () => {
     });
 });
 
-describe('web options', () => {
-    const webOptions = WebUtils.buildWebOptions(oneDriveOptions);
+describe('web options', async () => {
+    const webOptions = await WebUtils.buildWebOptions(oneDriveOptions);
     // console.log(webOptions);
 
     it('should build web options', () => {
@@ -160,8 +160,8 @@ describe("Random string gen", () => {
     });
 });
 
-describe("Authorization url building", () => {
-    const webOptions = WebUtils.buildWebOptions(oneDriveOptions);
+describe("Authorization url building", async () => {
+    const webOptions = await WebUtils.buildWebOptions(oneDriveOptions);
     const authorizationUrl = WebUtils.getAuthorizationUrl(webOptions);
 
     it('should contain a nonce param', () => {

--- a/src/web-utils.ts
+++ b/src/web-utils.ts
@@ -1,4 +1,4 @@
-import {OAuth2AuthenticateOptions} from "./definitions";
+import { OAuth2AuthenticateOptions } from "./definitions";
 // import sha256 from "fast-sha256";
 
 
@@ -46,15 +46,14 @@ export class WebUtils {
         return encodeURI(url);
     }
 
-    static getTokenEndpointData(options: WebOptions, code: string): FormData {
-        let data = new FormData();
-        data.append('grant_type', 'authorization_code');
-        data.append('client_id', options.appId);
-        data.append('redirect_uri', options.redirectUrl);
-        data.append('code', code);
-        data.append('code_verifier', options.pkceCodeVerifier);
-        // data.append('scope', options.scope);
-        return data;
+    static getTokenEndpointData(options: WebOptions, code: string): string {
+        let body = '';
+        body += encodeURIComponent('grant_type') + '=' + encodeURIComponent('authorization_code') + '&';
+        body += encodeURIComponent('client_id') + '=' + encodeURIComponent(options.appId) + '&';
+        body += encodeURIComponent('redirect_uri') + '=' + encodeURIComponent(options.redirectUrl) + '&';
+        body += encodeURIComponent('code') + '=' + encodeURIComponent(code) + '&';
+        body += encodeURIComponent('code_verifier') + '=' + encodeURIComponent(options.pkceCodeVerifier);
+        return body;
     }
 
     /**
@@ -96,7 +95,7 @@ export class WebUtils {
         return text;
     }
 
-    static buildWebOptions(configOptions: OAuth2AuthenticateOptions): WebOptions {
+    static async buildWebOptions(configOptions: OAuth2AuthenticateOptions): Promise<WebOptions> {
         const webOptions = new WebOptions();
         webOptions.appId = this.getAppId(configOptions);
         webOptions.responseType = this.getOverwritableValue(configOptions, "responseType");
@@ -109,7 +108,7 @@ export class WebUtils {
             if (!webOptions.pkceDisabled) {
                 webOptions.pkceCodeVerifier = this.randomString(64);
                 if (CryptoUtils.HAS_SUBTLE_CRYPTO) {
-                    CryptoUtils.deriveChallenge(webOptions.pkceCodeVerifier).then(c => {
+                    await CryptoUtils.deriveChallenge(webOptions.pkceCodeVerifier).then(c => {
                         webOptions.pkceCodeChallenge = c;
                         webOptions.pkceCodeChallengeMethod = "S256";
                     });

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,9 +1,9 @@
-import {WebPlugin} from '@capacitor/core';
-import {OAuth2AuthenticateOptions, OAuth2ClientPlugin} from "./definitions";
-import {WebOptions, WebUtils} from "./web-utils";
+import { registerWebPlugin, WebPlugin } from '@capacitor/core';
+import { OAuth2AuthenticateOptions, OAuth2ClientPlugin } from "./definitions";
+import { WebOptions, WebUtils } from "./web-utils";
 
 export class OAuth2ClientPluginWeb extends WebPlugin implements OAuth2ClientPlugin {
-
+ 
     private webOptions: WebOptions;
     private windowHandle: Window = null;
     private intervalId: number = null;
@@ -18,7 +18,7 @@ export class OAuth2ClientPluginWeb extends WebPlugin implements OAuth2ClientPlug
     }
 
     async authenticate(options: OAuth2AuthenticateOptions): Promise<any> {
-        this.webOptions = WebUtils.buildWebOptions(options);
+        this.webOptions = await WebUtils.buildWebOptions(options);
         return new Promise<any>((resolve, reject) => {
             // validate
             if (!this.webOptions.appId) {
@@ -162,6 +162,4 @@ const OAuth2Client = new OAuth2ClientPluginWeb();
 
 export { OAuth2Client };
 
-// this does not work for angular. You need to register the plugin in app.component.ts again.
-import { registerWebPlugin } from '@capacitor/core';
 registerWebPlugin(OAuth2Client);


### PR DESCRIPTION
When running as web/pwa, `the promise from CryptoUtils.deriveChallenge` was not being awaited properly so the pkceCodeChallenge was always `undefined` when being checking in the `buildOptions` function. I changed it to await properly so now it returns correctly to be used.

Also changed the token post request to be a string body rather than `FormData` object. When running with IdentityServer 4, the FormData object was causing a 400 error on the token request. Having a standard string body worked much better.