### PR TITLE
fix: replace Math.random with crypto #138

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,4 +13,7 @@ module.exports = {
     //     "^.+\\.(ts|tsx)$": "ts-jest"
     // },
     testEnvironment: 'node',
+    globals: {
+        window: {}
+    }
 };

--- a/src/web-utils.test.ts
+++ b/src/web-utils.test.ts
@@ -1,5 +1,10 @@
 import {OAuth2AuthenticateOptions} from "./definitions";
-import {CryptoUtils, WebUtils} from "./web-utils";
+import { CryptoUtils, WebUtils } from "./web-utils";
+
+const mGetRandomValues = jest.fn().mockReturnValueOnce(new Uint32Array(10));
+Object.defineProperty(window, 'crypto', {
+    value: { getRandomValues: mGetRandomValues },
+});
 
 const googleOptions: OAuth2AuthenticateOptions = {
     appId: "appId",

--- a/src/web-utils.ts
+++ b/src/web-utils.ts
@@ -87,12 +87,12 @@ export class WebUtils {
     static randomString(length: number = 10) {
         const possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
-        let text = "";
-        for (let i = 0; i < length; i++) {
-            text += possible.charAt(Math.floor(Math.random() * possible.length));
-        }
+        let array = new Uint8Array(length);
 
-        return text;
+        window.crypto.getRandomValues(array);
+        array = array.map(x => possible.charCodeAt(x % possible.length));
+
+        return String.fromCharCode.apply(null, array);
     }
 
     static async buildWebOptions(configOptions: OAuth2AuthenticateOptions): Promise<WebOptions> {


### PR DESCRIPTION
Fix for: https://github.com/moberwasserlechner/capacitor-oauth2/issues/138

I replaced `Math.random` with `window.crypto.getRandomValues` and configured jest to test the `randomString ` function correctly with the new globals.

Please consider if fallback is needed for `gerRandomValues`, the coverage is quite good otherwise: [caniuse.com](https://caniuse.com/?search=crypto.getRandomValues)