### PR TITLE
refactor: google code, bypass chrome window bug, default windowOptions

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -2,6 +2,9 @@ declare global {
     interface PluginRegistry {
         OAuth2Client?: OAuth2ClientPlugin;
     }
+    interface Window {
+        chrome: any;
+    }
 }
 
 export interface OAuth2ClientPlugin {

--- a/src/web-utils.ts
+++ b/src/web-utils.ts
@@ -217,7 +217,7 @@ export class WebOptions {
     scope: string;
     state: string;
     redirectUrl: string;
-    windowOptions: string;
+    windowOptions: string = "toolbar=no,location=yes,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=600,height=600,top=" + (screen.height - 600) / 2 + ",left=" + (screen.width - 600) / 2;
     windowTarget: string = "_blank";
 
     pkceEnabled: boolean;

--- a/src/web.ts
+++ b/src/web.ts
@@ -126,6 +126,9 @@ export class OAuth2ClientPluginWeb extends WebPlugin implements OAuth2ClientPlug
                         if(tokenObj.code) {
                             resp['code'] = tokenObj.code;
                         }
+                        if (tokenObj.id_token) {
+                            resp["id_token"] = tokenObj.id_token;
+                        }
                         resolve(resp);
                     } else {
                         reject(new Error(this.statusText));

--- a/src/web.ts
+++ b/src/web.ts
@@ -48,7 +48,8 @@ export class OAuth2ClientPluginWeb extends WebPlugin implements OAuth2ClientPlug
                     WebUtils.getAuthorizationUrl(this.webOptions),
                     this.webOptions.windowTarget,
                     this.webOptions.windowOptions,
-                    true);
+                    !!window.chrome ? undefined : true);
+
                 // wait for redirect and resolve the
                 this.intervalId = window.setInterval(() => {
                     if (loopCount-- < 0) {

--- a/src/web.ts
+++ b/src/web.ts
@@ -122,6 +122,9 @@ export class OAuth2ClientPluginWeb extends WebPlugin implements OAuth2ClientPlug
                         if (resp) {
                             resp["access_token"] = tokenObj.access_token;
                         }
+                        if(tokenObj.code) {
+                            resp['code'] = tokenObj.code;
+                        }
                         resolve(resp);
                     } else {
                         reject(new Error(this.statusText));


### PR DESCRIPTION
1. refactor: add google `code` and `id_token` to response,
Helper, same data sending to the server side one parameter `code` with all platforms including `web` 
by spec https://developers.google.com/identity/sign-in/web/server-side-flow

2. bypass chrome window bug 
https://bugs.chromium.org/p/chromium/issues/detail?id=1164959
<img width="778" alt="Screenshot 2021-04-21 at 04 40 58" src="https://user-images.githubusercontent.com/12596485/115485837-1f425b00-a25e-11eb-99ef-c40922f90194.png">

3. add default `windowOptions` based on google, set window to center on screen
would not rewrite the same code for all projects