### PR TITLE
Fix Android version of assignResponses

### DIFF
--- a/android/src/main/java/com/byteowls/capacitor/oauth2/OAuth2Utils.java
+++ b/android/src/main/java/com/byteowls/capacitor/oauth2/OAuth2Utils.java
@@ -10,10 +10,10 @@ public abstract class OAuth2Utils {
     public static void assignResponses(JSObject resp, String accessToken, AuthorizationResponse authorizationResponse, TokenResponse accessTokenResponse) {
         // #154
         if (authorizationResponse != null) {
-            resp.put("authorization_response", authorizationResponse.jsonSerializeString());
+            resp.put("authorization_response", authorizationResponse.jsonSerialize());
         }
         if (accessTokenResponse != null) {
-            resp.put("access_token_response", accessTokenResponse.jsonSerializeString());
+            resp.put("access_token_response", accessTokenResponse.jsonSerialize());
         }
         if (accessToken != null) {
             resp.put("access_token", accessToken);


### PR DESCRIPTION
The android version of assignResponses serializes authorizationResponse and accessTokenResponse to a json string, but it should serialize to json similar to OAuth2ClientPluginWeb.assignResponses.