### PR TITLE
Parse URL Parameters Properly

### DIFF
--- a/src/web-utils.test.ts
+++ b/src/web-utils.test.ts
@@ -191,7 +191,7 @@ describe("Url param extraction", () => {
         const foo = WebUtils.randomString();
         const paramObj = WebUtils.getUrlParams(`https://app.example.com?random=${random}&foo=${foo}#ignored`);
         expect(paramObj!["random"]).toStrictEqual(random);
-        expect(paramObj!["foo"]).toStrictEqual(`${foo}#ignored`);
+        expect(paramObj!["foo"]).toStrictEqual(`${foo}`);
     });
 
     it('should use hash flag and ignore query flag', () => {

--- a/src/web-utils.ts
+++ b/src/web-utils.ts
@@ -60,33 +60,24 @@ export class WebUtils {
      * Public only for testing
      */
     static getUrlParams(url: string): { [x: string]: string; } | undefined {
-        const urlString = `${url}`.trim();
+        const urlString = `${url ?? ''}`.trim();
 
         if (urlString.length === 0) {
             return;
         }
 
-        // #132
-        let hashIndex = urlString.indexOf("#");
-        let queryIndex = urlString.indexOf("?");
-
-        if (hashIndex === -1 && queryIndex === -1) {
+        const parsedUrl = new URL(urlString);
+        if (!parsedUrl.search && !parsedUrl.hash) {
             return;
         }
-        let paramsIndex: number;
-        if (hashIndex > -1 && queryIndex === -1) {
-            paramsIndex = hashIndex;
-        } else if (queryIndex > -1 && hashIndex === -1) {
-            paramsIndex = queryIndex;
+
+        let urlParamStr;
+        if (parsedUrl.search) {
+            urlParamStr = parsedUrl.search.substr(1);
         } else {
-            paramsIndex = hashIndex > -1 && hashIndex < queryIndex ? hashIndex : queryIndex;
+            urlParamStr = parsedUrl.hash.substr(1);
         }
 
-        if (urlString.length <= paramsIndex + 1) {
-            return;
-        }
-
-        const urlParamStr = urlString.slice(paramsIndex + 1);
         const keyValuePairs: string[] = urlParamStr.split(`&`);
         // @ts-ignore
         return keyValuePairs.reduce((accumulator, currentValue) => {


### PR DESCRIPTION
Currently, URL fragments are being treated as a part of the query string. These are two distinct pieces of a URL, and should be handled separately. This PR updates the logic within `WebUtils.getUrlParams()` to:
- Parse the `urlString` using the Javascript [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) interface. This interface properly separates the query string and fragment
- If the URL doesn't contain a query string or a fragment, return undefined
- If the URL contains a query string, parse its values, otherwise parse the fragment