### PR TITLE
fix `build.gradle` file

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,23 +1,37 @@
+ext {
+    appAuthVersion = project.hasProperty('appAuthVersion') ? rootProject.ext.appAuthVersion : '0.9.1'
+    androidxBrowserVersion = project.hasProperty('androidxBrowserVersion') ? rootProject.ext.androidxBrowserVersion : '1.3.0'
+    junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.1'
+    commonsIoVersion = project.hasProperty('commonsIoVersion') ? rootProject.ext.commonsIoVersion : '2.10.0'
+    androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.2.0'
+    junit5Version = project.hasProperty('junit5Version') ? rootProject.ext.junit5Version : '5.7.2'
+    androidJunit5Version = project.hasProperty('androidJunit5Version') ? rootProject.ext.androidJunit5Version : '1.2.2';
+    androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.4.0'
+}
+
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.2.1'
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 30
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 28
-        versionCode 2
-        versionName "2.0.0"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 21
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 30
+        versionCode 1
+        versionName "1.0"
+        // 1) Make sure to use the AndroidJUnitRunner, or a subclass of it. This requires a dependency on androidx.test:runner, too!
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        // 2) Connect JUnit 5 to the runner
+//        testInstrumentationRunnerArgument("runnerBuilder", "de.mannodermaus.junit5.AndroidJUnit5Builder")
     }
     buildTypes {
         release {
@@ -28,14 +42,16 @@ android {
     lintOptions {
         abortOnError false
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    testOptions {
-        unitTests {
-            includeAndroidResources = true
-        }
+
+    unitTestVariants.all {
+        it.mergedFlavor.manifestPlaceholders += [
+            appAuthRedirectScheme: "com.byteowls.capacitorapp"
+        ]
     }
 }
 
@@ -46,21 +62,19 @@ repositories {
 }
 
 dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
 
-    implementation 'androidx.browser:browser:1.0.0'
-    implementation 'net.openid:appauth:0.7.1'
-    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation "androidx.browser:browser:$androidxBrowserVersion"
+    implementation "net.openid:appauth:$appAuthVersion"
+    implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
 
-    testImplementation 'junit:junit:4.13'
-    // Optional -- Robolectric environment
-    // testImplementation 'androidx.test:core:1.2.0'
-    // Optional -- Mockito framework
-    // testImplementation 'org.mockito:mockito-core:1.10.19'
-
-    androidTestImplementation "commons-io:commons-io:2.6"
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    // 4) Jupiter API & Test Runner, if you don't have it already
+    testImplementation("org.junit.jupiter:junit-jupiter-params:${junit5Version}")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}") {
+        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+    }
+    testImplementation "commons-io:commons-io:$commonsIoVersion"
 }
 
 // ###############


### PR DESCRIPTION
Backported the fix for https://github.com/moberwasserlechner/capacitor-oauth2/issues/136 to the version of this plugin that supports Capacitor v2.

I think it would be best to create a `v2` branch in this project, then point this PR to that branch, and finally release a `v2.1.1` to npm (and GitHub)