### PR TITLE
fixed android logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,14 @@ import {OAuth2Client} from "@byteowls/capacitor-oauth2";
    '<button (click)="onLogoutClick()">Logout OAuth</button>'
 })
 export class SignupComponent {
+    accessToken: string;
     refreshToken: string;
 
     onOAuthBtnClick() {
         OAuth2Client.authenticate(
             oauth2Options
         ).then(response => {
-            let accessToken = response["access_token"];
+            this.accessToken = response["access_token"]; // storage recommended for android logout
             this.refreshToken = response["refresh_token"];
 
             // only if you include a resourceUrl protected user values are included in the response!
@@ -145,7 +146,7 @@ export class SignupComponent {
       OAuth2Client.refreshToken(
         oauth2RefreshOptions
       ).then(response => {
-        let accessToken = response["access_token"];
+        this.accessToken = response["access_token"]; // storage recommended for android logout
         // Don't forget to store the new refresh token as well!
         this.refreshToken = response["refresh_token"];
         // Go to backend
@@ -156,7 +157,8 @@ export class SignupComponent {
 
     onLogoutClick() {
             OAuth2Client.logout(
-                oauth2LogoutOptions
+                oauth2LogoutOptions,
+                this.accessToken // only used on android
             ).then(() => {
                 // do something
             }).catch(reason => {
@@ -362,6 +364,8 @@ android.buildTypes.release.manifestPlaceholders = [
 
 2) "ERR_ANDROID_RESULT_NULL": See [Issue #52](https://github.com/moberwasserlechner/capacitor-oauth2/issues/52#issuecomment-525715515) for details.
 I cannot reproduce this behaviour. Moreover there might be situation this state is valid. In other cases e.g. in the linked issue a configuration tweak fixed it.
+
+3) To prevent some logout issues on certain OAuth2 providers (like Salesforce for example), you should provide the `id_token` parameter on the `logout(...)` function. This ensures that not only the cookies are deleted, but also the logout link is called from the Oauth2 provider. Also, it uses the system browser that the plugin uses (and not the user's default browser) to call the logout URL. This additionally ensures that the cookies are deleted in the correct browser.
 
 ### Custom OAuth Handler
 

--- a/android/src/main/java/com/byteowls/capacitor/oauth2/OAuth2Options.java
+++ b/android/src/main/java/com/byteowls/capacitor/oauth2/OAuth2Options.java
@@ -36,6 +36,8 @@ public class OAuth2Options {
     private String prompt;
     private String responseMode;
 
+    private String logoutUrl;
+
 
     public String getAppId() {
         return appId;
@@ -214,5 +216,9 @@ public class OAuth2Options {
             }
             this.additionalResourceHeaders.put(key, value);
         }
+    }
+
+    public String getLogoutUrl() {
+        return logoutUrl;
     }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -14,9 +14,10 @@ export interface OAuth2ClientPlugin {
     /**
      * Logout from the authenticated OAuth 2 provider
      * @param {OAuth2AuthenticateOptions} options Although not all options are needed. We simply reuse the options from authenticate
+     * @param {String} id_token Optional idToken, only for Android
      * @returns {Promise<boolean>} true if the logout was successful else false.
      */
-    logout(options: OAuth2AuthenticateOptions): Promise<boolean>;
+    logout(options: OAuth2AuthenticateOptions, id_token?: string): Promise<boolean>;
 }
 
 export interface OAuth2RefreshTokenOptions {


### PR DESCRIPTION
As mentioned in https://github.com/moberwasserlechner/capacitor-oauth2/issues/97 there are currently some issues with the logout functionality. We discovered them only on Android, so this fix is only implementing a solution for Android. Our project uses SalesForce OAuth2 provider.  

We found that our users had problems with logout whenever they did not use their system's default browser. For example, if they had configured the Brave browser or Firefox as their default browser. In these cases we were not able to delete the session cookies. This is because this plugin always uses the system browser (usually Chrome), no matter what the user has set as default. But when we open a new browser window using Capacitor, the default browser configured by the user is used. And just not the system browser. 

That's why we implemented the logout functionality for Android and our users can now logout correctly on Android. No matter which browser they use and no matter which browser is default on their system.

I implemented the customization in such a way that no changes are necessary for existing applications. The code is fully backward compatible.

If you want to use the new logout functionality, you now have to pass the current `accessToken` as a second, optional, parameter to the `logout(...)` function (required by the Android plugin). If you do not pass the parameter, the plugin will behave as before.

I have adapted the documentation as good as possible. If it is incomplete or you want it to be different, please let me know. 